### PR TITLE
Remove custom Streamlit theme overrides

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,3 +1,1 @@
-[theme]
-base="light"
-primaryColor="green"
+# Use Streamlit's default theme colors by leaving the theme configuration empty.


### PR DESCRIPTION
## Summary
- remove the explicit theme overrides from `.streamlit/config.toml` so Streamlit falls back to Streamlit's defaults

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69027475c2fc8330956e2bf57f4ff34d