### PR TITLE
Adjust default speed presets

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,19 +32,19 @@ with st.sidebar:
         },
         "ULTRA_SLOWED": {
             "suffix": "Ultra Slowed",
-            "defaults": {"speed_factor": 0.6, "speed_percent": 60, "pitch_semitones": -9}
+            "defaults": {"speed_factor": 0.65, "speed_percent": 65, "pitch_semitones": -7}
         },
         "MEGA_SLOWED": {
             "suffix": "Mega Slowed",
-            "defaults": {"speed_factor": 0.5, "speed_percent": 50, "pitch_semitones": -12}
+            "defaults": {"speed_factor": 0.5, "speed_percent": 50, "pitch_semitones": -10}
         },
         "SPED_UP": {
             "suffix": "Sped Up",
-            "defaults": {"speed_factor": 1.2, "speed_percent": 120, "pitch_semitones": 3}
+            "defaults": {"speed_factor": 1.2, "speed_percent": 120, "pitch_semitones": 2}
         },
         "SUPER_SPED_UP": {
             "suffix": "Super Sped Up",
-            "defaults": {"speed_factor": 1.4, "speed_percent": 140, "pitch_semitones": 6}
+            "defaults": {"speed_factor": 1.4, "speed_percent": 140, "pitch_semitones": 5}
         }
     }
 


### PR DESCRIPTION
## Summary
- update the default speed and pitch settings for ultra slowed, mega slowed, sped up, and super sped up presets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69032afac9988330a1f1ee473c743327